### PR TITLE
Add TextWithPattern newtype for regex validation upon deserialization

### DIFF
--- a/aeson-deriving.cabal
+++ b/aeson-deriving.cabal
@@ -36,6 +36,8 @@ library
       Data.Aeson.Deriving.Known
       Data.Aeson.Deriving.ModifyField
       Data.Aeson.Deriving.SingleFieldObject
+      Data.Aeson.Deriving.Text
+      Data.Aeson.Deriving.Text.Unsafe
       Data.Aeson.Deriving.Utils
       Data.Aeson.Deriving.WithConstantFields
   other-modules:
@@ -47,6 +49,7 @@ library
   build-depends:
       aeson >=1.2 && <1.5
     , base >=4.7 && <5
+    , regex-tdfa
     , text
     , unordered-containers
   default-language: Haskell2010

--- a/src/Data/Aeson/Deriving.hs
+++ b/src/Data/Aeson/Deriving.hs
@@ -4,4 +4,5 @@ import           Data.Aeson.Deriving.Generic            as AllExports
 import           Data.Aeson.Deriving.Known              as AllExports
 import           Data.Aeson.Deriving.ModifyField        as AllExports
 import           Data.Aeson.Deriving.SingleFieldObject  as AllExports
+import           Data.Aeson.Deriving.Text               as AllExports
 import           Data.Aeson.Deriving.WithConstantFields as AllExports

--- a/src/Data/Aeson/Deriving/Text.hs
+++ b/src/Data/Aeson/Deriving/Text.hs
@@ -1,0 +1,5 @@
+module Data.Aeson.Deriving.Text
+  ( TextWithPattern
+  ) where
+
+import Data.Aeson.Deriving.Text.Unsafe (TextWithPattern)

--- a/src/Data/Aeson/Deriving/Text/Unsafe.hs
+++ b/src/Data/Aeson/Deriving/Text/Unsafe.hs
@@ -1,0 +1,17 @@
+module Data.Aeson.Deriving.Text.Unsafe where
+
+import           Control.Monad   (unless)
+import           Data.Aeson
+import           Data.Proxy
+import           Data.Text       (Text, unpack)
+import           Text.Regex.TDFA ((=~))
+import           GHC.TypeLits    (KnownSymbol, Symbol, symbolVal)
+
+newtype TextWithPattern (regex :: Symbol) = TextWithPattern Text
+  deriving newtype (ToJSON)
+
+instance KnownSymbol regex => FromJSON (TextWithPattern regex) where
+  parseJSON = withText "Text" $ \s ->
+    TextWithPattern <$> pure s <* unless (unpack s =~ (symbolVal $ Proxy @regex)) (fail errorMsg)
+    where
+      errorMsg = "must match regex " <> (symbolVal $ Proxy @regex)

--- a/src/Data/Aeson/Deriving/Text/Unsafe.hs
+++ b/src/Data/Aeson/Deriving/Text/Unsafe.hs
@@ -12,6 +12,6 @@ newtype TextWithPattern (regex :: Symbol) = TextWithPattern Text
 
 instance KnownSymbol regex => FromJSON (TextWithPattern regex) where
   parseJSON = withText "Text" $ \s ->
-    TextWithPattern <$> pure s <* unless (unpack s =~ (symbolVal $ Proxy @regex)) (fail errorMsg)
+    TextWithPattern s <$ unless (unpack s =~ (symbolVal $ Proxy @regex)) (fail errorMsg)
     where
       errorMsg = "must match regex " <> (symbolVal $ Proxy @regex)


### PR DESCRIPTION
This adds a newtype for regex validation. The `Unsafe` module name is needlessly scary, since it is what you would use whenever using `deriving via`, but it is unsafe in the sense that you can wrap arbitrary unvalidated data in the newtype with the exposed constructor. Maybe `Data.Aeson.Deriving.Text.Exposed` or something would be better?

Bikeshed ahoy!