### PR TITLE
Give `(==>)` its own kind

### DIFF
--- a/src/Data/Aeson/Deriving/Known.hs
+++ b/src/Data/Aeson/Deriving/Known.hs
@@ -5,7 +5,6 @@ module Data.Aeson.Deriving.Known where
 
 import           Data.Aeson
 import qualified Data.HashMap.Strict as HashMap
-import           Data.Kind           (Type)
 import           Data.Proxy
 import           Data.Text           (pack)
 import           GHC.TypeLits        (KnownSymbol, Symbol, symbolVal)
@@ -13,6 +12,8 @@ import           GHC.TypeLits        (KnownSymbol, Symbol, symbolVal)
 
 infix 3 :=
 infix 6 ==>
+infix 6 :==>
+infix 6 `To`
 
 
 -- | Represents the null JSON 'Value'.
@@ -25,9 +26,13 @@ data Null
 --   See "Data.Aeson.Deriving.WithConstantFields".
 data field := (value :: k)
 
+-- | Represents the kind of functions that map the one value to another,
+--   and otherwise do nothing but return the input.
+data a :==> b = a `To` b
+
 -- | Represents a function that maps the first value to the second,
 --   and otherwise does nothing but return the input.
-data a ==> b
+type (==>) = 'To
 
 -- | Represents the function that turns nulls into the given default value.
 data WithDefault (val :: k)
@@ -68,7 +73,7 @@ instance (KnownJSONObject fields, KnownSymbol key, KnownJSON val)
 
 
 -- | JSON ('Value') functions
-class KnownJSONFunction (a :: Type) where functionVal :: Proxy a -> Value -> Value
+class KnownJSONFunction (a :: k) where functionVal :: Proxy a -> Value -> Value
 
 -- instance All KnownJSON [a, b] => KnownJSONFunction (a ==> b) where
 instance (KnownJSON a, KnownJSON b) => KnownJSONFunction (a ==> b) where


### PR DESCRIPTION
Currently, the kind of type `"Foo" ==> "Bar"`, as revealed by ghci, is:

```haskell
>>> :kind! "Foo" ==> "Bar"
"Foo" ==> "Bar" :: *
```

However, for my current use case, I'd like to specify that a type has a phantom argument of the form `a ==> b`, where `a` and `b` are both `Symbol`s. In particular, I'd like to rule out other sorts of argument, such as `Type`s, `Type -> Type`s, etc.

That's where this PR comes in. With this declaration

```haskell
infix 6 :==>
infix 6 `To`
-- ...
data a :==> b = a `To` b
```

and with the `DataKinds` extension, we've defined four things:

Name | Level | Sort
------------ | -------|------
`(:==>)` | Type | (kind) `Type -> Type -> Type`
`(:==>)` | Kind | (sort) `Kind -> Kind -> Kind`
`To` | Value | (type) `a -> b -> (a :==> b)`
`'To` | Type | (kind) `a -> b -> (a :==> b)`

We don't really care about value-level `To` and type-level `(:==>)`, but afaik we still need them to get the one-level-up variants. 

Now, the *promoted* `'To` corresponds to the current `(==>)`, with the difference that the kind of `"Foo" '`To` "Bar"` is `Symbol :==> Symbol`:

```haskell
>>> :kind! "Foo" '`To` "Bar"
"Foo" '`To` "Bar" :: Symbol :==> Symbol
```

Finally, we define `(==>)` as the *promoted* `'To`, so we don't need to add a tick everywhere:

```haskell
infix 6 ==>
-- ...
type (==>) = 'To
```

### Notes

- I initially tried to define `data a :==> b = a ==> b`, but this isn't allowed by GHC since value constructors which are symbolic operators need to begin with `:`. That's why we need both the `data` and the `type` declarations (plus getting rid of the tick).

- I'm not entirely happy about the name `To`, but it's not very important since I'd expect users to mostly use `(==>)` and `(:==>)`. 