### PR TITLE
Empty object newtype

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,10 +1,12 @@
 # Changelog for aeson-deriving
 
-# Revision history for servant-openapi
+### 0.1.2
+
+* Added `EmptyObject` newtype for single-constructor types to be encoded as an empty JSON object.
 
 ### 0.1.1
 
-* Added newtype for Text validated against a regex pattern [PR 2](https://github.com/fieldstrength/aeson-deriving/pull/2)
+* Added `TextWithPattern` newtype for Text validated against a regex pattern [PR 2](https://github.com/fieldstrength/aeson-deriving/pull/2)
 
 ## 0.1.0
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ type MyEncoding = GenericEncoded
 
 data User = User
   { firstName :: Text
-  , id_       :: UserId        
+  , id_       :: UserId
   , companyId :: CompanyId
   }
   deriving stock (Generic, Show)
@@ -54,26 +54,41 @@ data Transaction = Transaction
   deriving stock (Generic, Show)
   deriving (FromJSON, ToJSON) via
     WithConstantFieldsOut
-      '[ "version" := "1.0"
-      , "system_info" := "👍" ]
-        MyEncoding Transaction
+     '[ "version" := "1.0"
+      , "system_info" := "👍"
+      ]
+      (MyEncoding Transaction)
 ```
 
 Note: Some newtypes that modify the instances come in an inbound and outbound variant. For example `WithConstantFields` is defined as the composition of `WithConstantFieldsIn` and `WithConstantFieldsOut`.
+
+#### Constant Objects
+
+Sometimes you may need an entire object of constant fields, with no information passing to the haskell representation. This is modeled as a single-value type and can also be used with the `WithConstantFields` newtype, as long as the base type is wrapped in the `EmptyObject` newtype (because otherwise unit types do not serialize to the empty object by default).
+
+```haskell
+data Requirements = Requirements
+  deriving (Show, Eq, Generic)
+  deriving (FromJSON, ToJSON) via
+    WithConstantFields
+     '[ "api_version" := "2.0"
+      , "check_performed" := 'True
+      ]
+      (EmptyObject Requirements)
+```
 
 #### Apply arbitrary functions before encoding/decoding
 
 ##### Example: Special treatment for magic values
 
 ```haskell
-
 data Feedback = Feedback
   { comment :: Text }
   deriving stock (Generic, Show)
   deriving (FromJSON, ToJSON) via
     ModifyFieldIn "comment"
       ("booo!" ==> "boo-urns!")
-        MyEncoding Feedback
+      (MyEncoding Feedback)
 
 
 -- x ==> y  maps the value x to y and leaves others unchanged

--- a/aeson-deriving.cabal
+++ b/aeson-deriving.cabal
@@ -4,10 +4,10 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 13bb59756d02d405b7d55bd3ba07fa0e3e02ff4a3bdf04774f8764952ec5c204
+-- hash: 05a421de32621a1d52633e1311198dbc32abe2ea1f27c1e0f003d14a579b97e5
 
 name:           aeson-deriving
-version:        0.1.1.1
+version:        0.1.1.2
 synopsis:       data types for compositional, type-directed serialization
 description:    Please see the README on GitHub at <https://github.com/fieldstrength/aeson-deriving#readme>
 category:       Serialization

--- a/aeson-deriving.cabal
+++ b/aeson-deriving.cabal
@@ -36,6 +36,7 @@ library
       Data.Aeson.Deriving.Known
       Data.Aeson.Deriving.ModifyField
       Data.Aeson.Deriving.SingleFieldObject
+      Data.Aeson.Deriving.EmptyObject
       Data.Aeson.Deriving.Utils
       Data.Aeson.Deriving.WithConstantFields
       Data.Aeson.Deriving.Text

--- a/aeson-deriving.cabal
+++ b/aeson-deriving.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: afa1a88618274c13cbf349c67513735bd434bd45398e9173e13419d361544a8a
+-- hash: 13bb59756d02d405b7d55bd3ba07fa0e3e02ff4a3bdf04774f8764952ec5c204
 
 name:           aeson-deriving
 version:        0.1.1.1
@@ -47,7 +47,7 @@ library
   default-extensions: ConstraintKinds DataKinds DeriveFunctor DeriveGeneric DerivingStrategies FlexibleContexts FlexibleInstances GeneralizedNewtypeDeriving KindSignatures LambdaCase MultiParamTypeClasses NamedFieldPuns OverloadedStrings ScopedTypeVariables TupleSections TypeApplications TypeOperators
   ghc-options: -Wall -Wredundant-constraints -Wincomplete-record-updates -Wincomplete-uni-patterns
   build-depends:
-      aeson >=1.2 && <1.5
+      aeson >=1.2 && <1.6
     , base >=4.7 && <5
     , regex-tdfa
     , text
@@ -64,7 +64,7 @@ test-suite spec
   default-extensions: ConstraintKinds DataKinds DeriveFunctor DeriveGeneric DerivingStrategies FlexibleContexts FlexibleInstances GeneralizedNewtypeDeriving KindSignatures LambdaCase MultiParamTypeClasses NamedFieldPuns OverloadedStrings ScopedTypeVariables TupleSections TypeApplications TypeOperators
   ghc-options: -Wall -Wredundant-constraints -Wincomplete-record-updates -Wincomplete-uni-patterns
   build-depends:
-      aeson >=1.2 && <1.5
+      aeson >=1.2 && <1.6
     , aeson-deriving
     , base >=4.7 && <5
     , hedgehog

--- a/package.yaml
+++ b/package.yaml
@@ -37,7 +37,7 @@ default-extensions:
 
 dependencies:
     - base >= 4.7 && < 5
-    - aeson >= 1.2 && < 1.5
+    - aeson >= 1.2 && < 1.6
     - unordered-containers
     - text
     - regex-tdfa

--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name:                aeson-deriving
-version:             0.1.1.1
+version:             0.1.1.2
 github:              "fieldstrength/aeson-deriving"
 license:             MIT
 author:              "Cliff Harvey"

--- a/package.yaml
+++ b/package.yaml
@@ -73,6 +73,7 @@ library:
         - Data.Aeson.Deriving.Known
         - Data.Aeson.Deriving.ModifyField
         - Data.Aeson.Deriving.SingleFieldObject
+        - Data.Aeson.Deriving.EmptyObject
         - Data.Aeson.Deriving.Utils
         - Data.Aeson.Deriving.WithConstantFields
         - Data.Aeson.Deriving.Text

--- a/src/Data/Aeson/Deriving.hs
+++ b/src/Data/Aeson/Deriving.hs
@@ -6,3 +6,4 @@ import           Data.Aeson.Deriving.ModifyField        as AllExports
 import           Data.Aeson.Deriving.SingleFieldObject  as AllExports
 import           Data.Aeson.Deriving.Text               as AllExports
 import           Data.Aeson.Deriving.WithConstantFields as AllExports
+import           Data.Aeson.Deriving.EmptyObject        as AllExports

--- a/src/Data/Aeson/Deriving/EmptyObject.hs
+++ b/src/Data/Aeson/Deriving/EmptyObject.hs
@@ -1,0 +1,36 @@
+{-# LANGUAGE UndecidableInstances #-}
+
+-- | Allow unit-like types to be serialized as the empty object
+--   This can be combined with 'WithConstantFields'.
+module Data.Aeson.Deriving.EmptyObject where
+
+import Data.Aeson
+import Data.Kind (Type)
+import GHC.Generics
+
+-- | For data types with exactly one value, this data type changes the serialization to be the empty JSON object.
+--   It can be combined with 'WithConstantFields'.
+newtype EmptyObject a = EmptyObject a
+
+instance UnitLike (Rep a) => ToJSON (EmptyObject a) where
+  toJSON _ = object []
+
+instance (Generic a, UnitLike (Rep a)) => FromJSON (EmptyObject a) where
+  parseJSON = withObject "object" $ \_hashmap ->
+    pure . EmptyObject $ to gPoint
+
+
+-- | class for data types with a single constructor
+class UnitLike (f :: Type -> Type) where
+  gPoint :: f a
+
+instance UnitLike U1 where
+  gPoint = U1
+
+instance UnitLike a => UnitLike (M1 C meta a) where
+  gPoint = M1 gPoint
+
+instance UnitLike a => UnitLike (M1 D meta a) where
+  gPoint = M1 gPoint
+
+

--- a/src/Data/Aeson/Deriving/Internal/Generic.hs
+++ b/src/Data/Aeson/Deriving/Internal/Generic.hs
@@ -5,8 +5,9 @@
 module Data.Aeson.Deriving.Internal.Generic where
 
 import           Data.Aeson
-import           Data.Aeson.Deriving.Known
+import           Data.Aeson.Deriving.EmptyObject        (EmptyObject(..))
 import           Data.Aeson.Deriving.Internal.RecordSum
+import           Data.Aeson.Deriving.Known
 import           Data.Aeson.Deriving.Utils
 import           Data.Aeson.Types                       (modifyFailure)
 import           Data.Char                              (isUpper, toLower, toUpper)
@@ -191,6 +192,7 @@ instance
 type family LoopWarning (n :: Type -> Type) (a :: Type) :: Constraint where
   LoopWarning n (GenericEncoded opts a) = ()
   LoopWarning n (RecordSumEncoded tagKey tagValMod a) = ()
+  LoopWarning n (EmptyObject a) = ()
   LoopWarning n (DisableLoopWarning a) = ()
   LoopWarning n (x & f) = LoopWarning n (f x)
   LoopWarning n (f x) = LoopWarning n x

--- a/src/Data/Aeson/Deriving/WithConstantFields.hs
+++ b/src/Data/Aeson/Deriving/WithConstantFields.hs
@@ -49,5 +49,7 @@ instance (FromJSON a, LoopWarning (WithConstantFields obj) a, KnownJSONObject ob
         flip (withObject "Object") valIn $ \obj -> do
           valActual <- obj .: key
           unless (valActual == valExpected) . fail $
-            "Expected constant value `" <> show valExpected <> "` but got: " <>
-            show valActual
+            "Expected constant value " <> showEscapedJson valExpected <>
+            " but got: " <> showEscapedJson valActual
+
+      showEscapedJson val = show (encode val)

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,5 +1,5 @@
 
-resolver: nightly-2019-11-07
+resolver: lts-16.12
 
 packages:
     - .

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -6,7 +6,7 @@
 packages: []
 snapshots:
 - completed:
-    size: 414284
-    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/nightly/2019/11/7.yaml
-    sha256: 83a39c911b888c1ad92d854d6d43fdca2ece0574739634680762a9f315ff7630
-  original: nightly-2019-11-07
+    size: 532377
+    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/16/12.yaml
+    sha256: f914cfa23fef85bdf895e300a8234d9d0edc2dbec67f4bc9c53f85867c50eab6
+  original: lts-16.12

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -250,4 +250,4 @@ prop_constant_object_decodes_as_expected = once . property $ tripping Requiremen
 prop_reject_constant_object_with_incorrect_details :: Property
 prop_reject_constant_object_with_incorrect_details = once . property $
   eitherDecode @Requirements "{\"api_version\":\"2.0\",\"check_performed\":false}"
-    === Left "Error in $: Expected constant value `Bool True` but got: Bool False"
+    === Left "Error in $: Expected constant value \"true\" but got: \"false\""


### PR DESCRIPTION
This feature is primarily motivated by the combined functionality with `WithConstantFields`, because unit types do not serialize to the empty object by default but rather to the empty list.

See ReadMe/test for example.